### PR TITLE
Update build information for temporary publish to PyPI

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,65 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip_existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wheelhouse
 ssh2/libssh2.so*
 doc/_build
 ven*
+.vscode

--- a/ci/docker/manylinux/Dockerfile
+++ b/ci/docker/manylinux/Dockerfile
@@ -13,11 +13,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
-ENV OPENSSL openssl-1.1.1q
+ENV OPENSSL openssl-3.1.4
 ENV SYSTEM_LIBSSH2 1
-ENV LIBSSH2_VERSION 1.10.0
+ENV LIBSSH2_VERSION 1.11.0
 
 RUN yum install zlib-devel -y
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = ssh2/_version.py
-tag_prefix = ''
-
 [bdist_wheel]
 universal = 0
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from glob import glob
 
 from _setup_libssh2 import build_ssh2
 
-import versioneer
+# import versioneer
 from setuptools import setup, find_packages
 
 cpython = platform.python_implementation() == 'CPython'
@@ -87,15 +87,15 @@ if ON_WINDOWS:
         'msvc*.dll', 'vcruntime*.dll',
     ])
 
-cmdclass = versioneer.get_cmdclass()
-if USING_CYTHON:
-    cmdclass['build_ext'] = build_ext
+# cmdclass = versioneer.get_cmdclass()
+# if USING_CYTHON:
+#     cmdclass['build_ext'] = build_ext
 
 setup(
-    name='ssh2-python',
-    version=versioneer.get_version(),
-    cmdclass=cmdclass,
-    url='https://github.com/ParallelSSH/ssh2-python',
+    name='ssh2-python312',
+    version="0.1.0",
+    # cmdclass=cmdclass,
+    url='https://github.com/jacobcallahan/ssh2-python',
     license='LGPLv2',
     author='Panos Kittenis',
     author_email='22e889d8@opayq.com',
@@ -116,11 +116,9 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Shells',
         'Topic :: System :: Networking',
         'Topic :: Software Development :: Libraries',
@@ -128,7 +126,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: POSIX :: Linux',
         'Operating System :: POSIX :: BSD',
-        'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
     ],
     ext_modules=cythonize(extensions, **cython_args) if USING_CYTHON else extensions,


### PR DESCRIPTION
This changes the name of the package to ssh2-python312 and uses a github action to build for both linux and mac before publishing to pypi.

In this form, the versioning is hard-coded into setup.py, but good enough for the infrequency in which this should be pushed.